### PR TITLE
feat: remove codecov report upload.

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -29,3 +29,19 @@ jobs:
         cd youtube-playlist-downloader
         poetry run coverage run -m pytest
         poetry run coverage report
+        poetry run coverage report > coverage_report.txt
+    - name: Post coverage comment
+      uses: actions/github-script@v6
+      if: github.event_name == 'pull_request'
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+            const fs = require('fs')
+            const coverageReport = fs.readFileSync('youtube-playlist-downloader/coverage_report.txt', 'utf8')
+            const pullRequestId = context.payload.pull_request.number
+            github.rest.pulls.createComment({
+                issue_number: pullRequestId,
+                owner: context.repo.owner,
+                repo: context.repo.name,
+                body: '## Coverage Report\n```\n' + coverageReport + '\n```'
+            })

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -27,11 +27,5 @@ jobs:
     - name: Run tests with pytest and coverage
       run: |
         cd youtube-playlist-downloader
-        poetry run pytest tests --cov=. --cov-report=xml
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./youtube-playlist-downloader/coverage.xml
-        flags: unittests
-        fail_ci_if_error: true
+        poetry run coverage run -m pytest
+        poetry run coverage report


### PR DESCRIPTION
# Update Test Coverage Workflow

## Description
This pull request modifies the test and coverage workflow to use the `coverage` command directly instead of relying on pytest-cov and Codecov integration.

## Changes
- Removed the pytest-cov command and replaced it with `coverage run -m pytest`
- Added a step to generate a coverage report using `coverage report`
- Removed the Codecov upload step

## Rationale
- Simplifies the workflow by using the `coverage` tool directly
- Generates a coverage report that can be viewed directly in the GitHub Actions log
- Eliminates dependency on external services (Codecov) for viewing coverage results

## How to Test
1. Run the GitHub Action by pushing a commit or creating a pull request
2. Check the Action logs to ensure tests are running correctly
3. Verify that the coverage report is generated and visible in the logs

## Impact
- Coverage information will no longer be available through Codecov
- Coverage reports will be available directly in the GitHub Actions logs
- This change may affect any badges or integrations that were relying on Codecov

## Additional Notes
- If we need to persist or analyze coverage data over time, we may need to implement a solution to store and track these reports
- Consider adding a step to fail the workflow if coverage falls below a certain threshold

Please review these changes and let me know if any adjustments or additional information is needed.